### PR TITLE
Implement command invoker and interface for commands

### DIFF
--- a/AWN/CommandInvoker.cs
+++ b/AWN/CommandInvoker.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AWN
+{
+    public class CommandInvoker
+    {
+        private readonly IEnumerable<ICommand> _commands;
+
+        public CommandInvoker(IEnumerable<ICommand> commands)
+        {
+            _commands = commands;
+        }
+
+        public async Task<string> ExecuteCommandAsync(string commandInput)
+        {
+            foreach (var command in _commands)
+            {
+                if (command.CanExecute(commandInput))
+                {
+                    return await command.ExecuteAsync(commandInput);
+                }
+            }
+
+            return "No command executed.";
+        }
+    }
+}

--- a/AWN/ICommand.cs
+++ b/AWN/ICommand.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace AWN
+{
+    public interface ICommand
+    {
+        bool CanExecute(string commandInput);
+        Task<string> ExecuteAsync(string commandInput);
+    }
+}

--- a/AWN/Program.cs
+++ b/AWN/Program.cs
@@ -1,1 +1,5 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWN;
+
 Console.WriteLine("Hello World!");


### PR DESCRIPTION
Related to #1

Implement `CommandInvoker` class and `ICommand` interface.

* **CommandInvoker Class**
  - Add `CommandInvoker` class in `AWN/CommandInvoker.cs`.
  - Implement constructor accepting `IEnumerable<ICommand>`.
  - Implement `ExecuteCommandAsync` method that takes a `string` parameter and returns a `Task<string>`.
  - Iterate over `_commands` collection and execute the first command that matches `CanExecute` method.

* **ICommand Interface**
  - Add `ICommand` interface in `AWN/ICommand.cs`.
  - Define `CanExecute` method that takes a `string` parameter and returns a `bool`.
  - Define `ExecuteAsync` method that takes a `string` parameter and returns a `Task<string>`.

* **Program.cs Modifications**
  - Add using directives for `System.Collections.Generic`, `System.Threading.Tasks`, and `AWN` namespace.

